### PR TITLE
change: Do a first run of all gates and noises at import to force com…

### DIFF
--- a/src/braket/simulator_v2/__init__.py
+++ b/src/braket/simulator_v2/__init__.py
@@ -6,25 +6,4 @@ from braket.simulator_v2.state_vector_simulator_v2 import (  # noqa: F401
     StateVectorSimulatorV2,
 )
 
-# at init run many commonly used gates and noises to force compilation
-# for this Python session
-# must be done at init because each new Python session has a separate handle and
-# seems to invalidate old methods
-from braket.circuits.circuit import Circuit
-from braket.circuits.serialization import IRType
-
 from ._version import __version__  # noqa: F401
-
-c = Circuit().h(0).cnot(0, 1).rx(0, 0.1).ry(1, 0.2).rz(0, 0.1)
-c.x(0).y(1).z(0).zz(0, 1, 0.2).xx(0, 1, 0.1).yy(0, 1, 0.1).xy(0, 1, 0.2)
-c.swap(1, 0).ecr(0, 1).gpi(0, 0.1).gpi2(1, 0.2).ms(0, 1, 0.1, 0.2, 0.3)
-c.iswap(1, 0).pswap(0, 1, 0.2).cphaseshift(0, 1, 0.2).cphaseshift00(1, 0, 0.2)
-c.cphaseshift01(1, 0, 0.2).cphaseshift10(0, 1, 0.2).phaseshift(0, 0.2)
-c.ccnot(1, 0, 2).cswap(0, 1, 2)
-device = StateVectorSimulatorV2()
-device.run(c.to_ir(IRType.OPENQASM), shots=100)
-c = Circuit().h(0).cnot(0, 1)
-c.bit_flip(0, 0.1).phase_flip(0, 0.2).amplitude_damping(1, 0.1).phase_damping(0, 0.2)
-c.two_qubit_dephasing(0, 1, 0.2).depolarizing(1, 0.2).two_qubit_depolarizing(1, 0, 0.1)
-device = DensityMatrixSimulatorV2()
-device.run(c.to_ir(IRType.OPENQASM), shots=100)

--- a/src/braket/simulator_v2/julia_import.py
+++ b/src/braket/simulator_v2/julia_import.py
@@ -36,6 +36,9 @@ else:
     ):
         os.environ[k] = os.environ.get(k, default)
 
+import braket.default_simulator.gate_operations as gates
+import braket.default_simulator.noise_operations as noises
+from braket.default_simulator.openqasm.circuit import Circuit
 import juliacall
 
 jl = juliacall.Base.Module()
@@ -43,3 +46,78 @@ jl = juliacall.Base.Module()
 jl.seval("using PythonCall, BraketSimulator")
 jl.seval("using PythonCall: Py, pyconvert")
 jlBraketSimulator = jl.BraketSimulator
+
+# at init run many commonly used gates and noises to force compilation
+# for this Python session
+# must be done at init because each new Python session has a separate handle and
+# seems to invalidate old methods
+
+circuit = Circuit()
+for instruction in (
+    gates.Hadamard(targets=[0]),
+    gates.RotX(targets=[0], angle=0.1),
+    gates.RotY(targets=[1], angle=0.2),
+    gates.RotZ(targets=[0], angle=0.1),
+    gates.PhaseShift(targets=[0], angle=0.1),
+    gates.PRx(targets=[0], angle_1=0.1, angle_2=0.2),
+    gates.GPi(targets=[0], angle=0.1),
+    gates.GPi2(targets=[0], angle=0.1),
+    gates.PauliX(targets=[0]),
+    gates.PauliY(targets=[1]),
+    gates.PauliZ(targets=[0]),
+    gates.V(targets=[0]),
+    gates.Vi(targets=[1]),
+    gates.S(targets=[0]),
+    gates.Si(targets=[1]),
+    gates.T(targets=[0]),
+    gates.Ti(targets=[1]),
+    gates.Identity(targets=[1]),
+    gates.Swap(targets=[0, 1]),
+    gates.ISwap(targets=[0, 1]),
+    gates.PSwap(targets=[0, 1], angle=0.1),
+    gates.ECR(targets=[0, 1]),
+    gates.CX(targets=[0, 1]),
+    gates.CY(targets=[0, 1]),
+    gates.CZ(targets=[0, 1]),
+    gates.CV(targets=[0, 1]),
+    gates.MS(targets=[0, 1], angle_1=0.1, angle_2=0.2, angle_3=0.3),
+    gates.XX(targets=[0, 1], angle=0.1),
+    gates.XY(targets=[0, 1], angle=0.1),
+    gates.YY(targets=[0, 1], angle=0.1),
+    gates.ZZ(targets=[0, 1], angle=0.1),
+    gates.CPhaseShift(targets=[0, 1], angle=0.1),
+    gates.CPhaseShift00(targets=[0, 1], angle=0.1),
+    gates.CPhaseShift10(targets=[0, 1], angle=0.1),
+    gates.CPhaseShift01(targets=[0, 1], angle=0.1),
+    gates.CCNot(targets=[0, 1, 2]),
+    gates.CSwap(targets=[0, 1, 2]),
+):
+    circuit.add_instruction(instruction)
+
+jl.simulate(
+    jlBraketSimulator.StateVectorSimulator(0, 0), [circuit], 3, 100, measured_qubits=[]
+)
+
+circuit = Circuit()
+for instruction in (
+    gates.Hadamard(targets=[0]),
+    gates.CX(targets=[0, 1]),
+    noises.BitFlip(targets=[0], probability=0.1),
+    noises.PhaseFlip(targets=[0], probability=0.1),
+    noises.PauliChannel(targets=[0], probX=0.1, probY=0.2, probZ=0.3),
+    noises.Depolarizing(targets=[0], probability=0.1),
+    noises.TwoQubitDepolarizing(targets=[0, 1], probability=0.1),
+    noises.TwoQubitDephasing(targets=[0, 1], probability=0.1),
+    noises.AmplitudeDamping(targets=[0], gamma=0.1),
+    noises.PhaseDamping(targets=[0], gamma=0.1),
+    noises.GeneralizedAmplitudeDamping(targets=[0], gamma=0.1, probability=0.2),
+):
+    circuit.add_instruction(instruction)
+
+jl.simulate(
+    jlBraketSimulator.DensityMatrixSimulator(0, 0),
+    [circuit],
+    3,
+    100,
+    measured_qubits=[],
+)


### PR DESCRIPTION
…pilation

*Issue #, if available:* N/A

*Description of changes:* Force a first translation of all gates and noises at import to trigger precompilation. For now this must be done at each import because each new Python session creates a new handle to the Python runtime, which invalidates previously compiled Julia translation methods. Also fixes entry points in `pyproject.toml`.

*Testing done:* After changes first run goes from 8s to 0.007s.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-simulator-v2-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-simulator-v2-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-simulator-v2-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-simulator-v2-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
