### PR TITLE
fix: Also turn list values to ndarray for Probability result types

### DIFF
--- a/src/braket/simulator_v2/base_simulator_v2.py
+++ b/src/braket/simulator_v2/base_simulator_v2.py
@@ -15,7 +15,6 @@ from braket.simulator_v2.julia_import import jl
 
 
 class BaseLocalSimulatorV2(BaseLocalSimulator, ABC):
-
     def __init__(self, device):
         self._device = device
 

--- a/src/braket/simulator_v2/base_simulator_v2.py
+++ b/src/braket/simulator_v2/base_simulator_v2.py
@@ -163,11 +163,7 @@ def _result_value_to_ndarray(
     with the pydantic specification for ResultTypeValues.
     """
     for result_ind, result_type in enumerate(task_result.resultTypes):
-        if (
-            isinstance(result_type.type, StateVector)
-            or isinstance(result_type.type, DensityMatrix)
-            or isinstance(result_type.type, Probability)
-        ):
+        if isinstance(result_type.type, (StateVector, DensityMatrix, Probability)):
             task_result.resultTypes[result_ind].value = np.asarray(
                 task_result.resultTypes[result_ind].value
             )

--- a/src/braket/simulator_v2/base_simulator_v2.py
+++ b/src/braket/simulator_v2/base_simulator_v2.py
@@ -5,7 +5,7 @@ from braket.default_simulator.operation_helpers import from_braket_instruction
 from braket.default_simulator.result_types import TargetedResultType
 from braket.default_simulator.simulator import BaseLocalSimulator
 from braket.device_schema import DeviceActionType
-from braket.ir.jaqcd import DensityMatrix
+from braket.ir.jaqcd import DensityMatrix, Probability
 from braket.ir.jaqcd import Program as JaqcdProgram
 from braket.ir.jaqcd import StateVector
 from braket.ir.openqasm import Program as OpenQASMProgram
@@ -82,8 +82,7 @@ class BaseLocalSimulatorV2(BaseLocalSimulator, ABC):
             )
         r = jl.simulate(self._device, [circuit_ir], qubit_count, shots)
         r.additionalMetadata.action = circuit_ir
-        if not shots:
-            r = _analytic_result_value_to_ndarray(r)
+        r = _result_value_to_ndarray(r)
         return r
 
     def run_openqasm(
@@ -153,11 +152,11 @@ class BaseLocalSimulatorV2(BaseLocalSimulator, ABC):
         if shots:
             r.resultTypes = results
         else:
-            r = _analytic_result_value_to_ndarray(r)
+            r = _result_value_to_ndarray(r)
         return r
 
 
-def _analytic_result_value_to_ndarray(
+def _result_value_to_ndarray(
     task_result: GateModelTaskResult,
 ) -> GateModelTaskResult:
     """Convert any StateVector or DensityMatrix result values from raw Python lists to the expected
@@ -165,8 +164,10 @@ def _analytic_result_value_to_ndarray(
     with the pydantic specification for ResultTypeValues.
     """
     for result_ind, result_type in enumerate(task_result.resultTypes):
-        if isinstance(result_type.type, StateVector) or isinstance(
-            result_type.type, DensityMatrix
+        if (
+            isinstance(result_type.type, StateVector)
+            or isinstance(result_type.type, DensityMatrix)
+            or isinstance(result_type.type, Probability)
         ):
             task_result.resultTypes[result_ind].value = np.asarray(
                 task_result.resultTypes[result_ind].value

--- a/test/unit_tests/braket/simulator_v2/test_density_matrix_simulator_v2.py
+++ b/test/unit_tests/braket/simulator_v2/test_density_matrix_simulator_v2.py
@@ -22,7 +22,7 @@ from braket.device_schema.simulators import (
     GateModelSimulatorDeviceCapabilities,
     GateModelSimulatorDeviceParameters,
 )
-from braket.ir.jaqcd import DensityMatrix, Expectation
+from braket.ir.jaqcd import DensityMatrix, Expectation, Probability
 from braket.ir.jaqcd import Program as JaqcdProgram
 from braket.ir.openqasm import Program as OpenQASMProgram
 from braket.task_result import AdditionalMetadata, TaskMetadata
@@ -847,11 +847,11 @@ def test_measure_targets():
     assert len(measurements[0]) == 1
     assert result.measuredQubits == [0]
 
-
 @pytest.mark.parametrize(
     "jaqcd_string, oq3_pragma, jaqcd_type",
     [
         ["densitymatrix", "density_matrix", DensityMatrix()],
+        ["probability", "probability", Probability()],
     ],
 )
 def test_simulator_analytic_value_type(jaqcd_string, oq3_pragma, jaqcd_type):

--- a/test/unit_tests/braket/simulator_v2/test_density_matrix_simulator_v2.py
+++ b/test/unit_tests/braket/simulator_v2/test_density_matrix_simulator_v2.py
@@ -847,6 +847,7 @@ def test_measure_targets():
     assert len(measurements[0]) == 1
     assert result.measuredQubits == [0]
 
+
 @pytest.mark.parametrize(
     "jaqcd_string, oq3_pragma, jaqcd_type",
     [

--- a/test/unit_tests/braket/simulator_v2/test_state_vector_simulator_v2.py
+++ b/test/unit_tests/braket/simulator_v2/test_state_vector_simulator_v2.py
@@ -1415,6 +1415,7 @@ def test_rotation_parameter_expressions(operation, state_vector):
     assert result.resultTypes[0].type == StateVector()
     assert np.allclose(result.resultTypes[0].value, np.array(state_vector))
 
+
 @pytest.mark.parametrize(
     "jaqcd_string, oq3_pragma, jaqcd_type",
     [

--- a/test/unit_tests/braket/simulator_v2/test_state_vector_simulator_v2.py
+++ b/test/unit_tests/braket/simulator_v2/test_state_vector_simulator_v2.py
@@ -1415,12 +1415,12 @@ def test_rotation_parameter_expressions(operation, state_vector):
     assert result.resultTypes[0].type == StateVector()
     assert np.allclose(result.resultTypes[0].value, np.array(state_vector))
 
-
 @pytest.mark.parametrize(
     "jaqcd_string, oq3_pragma, jaqcd_type",
     [
         ["statevector", "state_vector", StateVector()],
         ["densitymatrix", "density_matrix", DensityMatrix()],
+        ["probability", "probability", Probability()],
     ],
 )
 def test_simulator_analytic_value_type(jaqcd_string, oq3_pragma, jaqcd_type):


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Force `Probability` result values to be `ndarray`. For JAQCD we have to do this for the `GateModelTaskResult` for `shots>0` as well because `Probability` is a valid result type there, but for OpenQASM we shouldn't need to since that is computed by the BDK.

*Testing done:* `tox` passed locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-simulator-v2-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-simulator-v2-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-simulator-v2-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-simulator-v2-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
