### PR TITLE
fix: StateVector shouldn't be a supported pragma for DM simulator

### DIFF
--- a/src/braket/simulator_v2/base_simulator_v2.py
+++ b/src/braket/simulator_v2/base_simulator_v2.py
@@ -3,7 +3,6 @@ import warnings
 from collections.abc import Sequence
 from typing import Any, Optional, Union
 
-import juliacall
 import numpy as np
 from braket.default_simulator.result_types import TargetedResultType
 from braket.default_simulator.simulator import BaseLocalSimulator
@@ -100,7 +99,7 @@ class BaseLocalSimulatorV2(BaseLocalSimulator):
         translated_ir, qubit_count = self._jaqcd_to_jl(circuit_ir, shots)
         try:
             r = jl.simulate(self._device, translated_ir, qubit_count, shots)
-        except juliacall.JuliaError as e:
+        except JuliaError as e:
             _handle_julia_error(e)
         r.additionalMetadata.action = circuit_ir
         r = _result_value_to_ndarray(r)
@@ -158,7 +157,7 @@ class BaseLocalSimulatorV2(BaseLocalSimulator):
         """
         try:
             r = jl.simulate(self._device, self._openqasm_to_jl(openqasm_ir), shots)
-        except juliacall.JuliaError as e:
+        except JuliaError as e:
             _handle_julia_error(e)
         r.additionalMetadata.action = openqasm_ir
         # attach the result types
@@ -209,7 +208,7 @@ class BaseLocalSimulatorV2(BaseLocalSimulator):
                 shots=shots,
                 inputs=inputs,
             )
-        except juliacall.JuliaError as e:
+        except JuliaError as e:
             _handle_julia_error(e)
 
         for r_ix, result in enumerate(results):

--- a/src/braket/simulator_v2/density_matrix_simulator_v2.py
+++ b/src/braket/simulator_v2/density_matrix_simulator_v2.py
@@ -115,7 +115,6 @@ class DensityMatrixSimulatorV2(BaseLocalSimulatorV2):
                         ],
                         "supportedPragmas": [
                             "braket_unitary_matrix",
-                            "braket_result_type_state_vector",
                             "braket_result_type_density_matrix",
                             "braket_result_type_sample",
                             "braket_result_type_expectation",

--- a/src/braket/simulator_v2/julia_import.py
+++ b/src/braket/simulator_v2/julia_import.py
@@ -5,36 +5,29 @@ import warnings
 # Check if JuliaCall is already loaded, and if so, warn the user
 # about the relevant environment variables. If not loaded,
 # set up sensible defaults.
-if "juliacall" in sys.modules:
+# Required to avoid segfaults (https://juliapy.github.io/PythonCall.jl/dev/faq/)
+if os.environ.get("PYTHON_JULIACALL_HANDLE_SIGNALS", "yes") != "yes":
     warnings.warn(
-        "`juliacall` module has already been imported. "
-        + "Make sure that you have set the environment variable "
-        + "`PYTHON_JULIACALL_HANDLE_SIGNALS=yes` to avoid segfaults. "
+        "`PYTHON_JULIACALL_HANDLE_SIGNALS` environment variable "
+        + "is set to something other than 'yes' or ''. "
+        + "You will experience segfaults if running with Julia multithreading."
     )
-else:
-    # Required to avoid segfaults (https://juliapy.github.io/PythonCall.jl/dev/faq/)
-    if os.environ.get("PYTHON_JULIACALL_HANDLE_SIGNALS", "yes") != "yes":
-        warnings.warn(
-            "`PYTHON_JULIACALL_HANDLE_SIGNALS` environment variable "
-            + "is set to something other than 'yes' or ''. "
-            + "You will experience segfaults if running with Julia multithreading."
-        )
 
-    if os.environ.get("PYTHON_JULIACALL_THREADS", "auto") != "auto":
-        warnings.warn(
-            "`PYTHON_JULIACALL_THREADS` environment variable is set to "
-            + "something other than `auto`, so `amazon-braket-simulator-v2` "
-            + "was not able to set it."
-        )
+if os.environ.get("PYTHON_JULIACALL_THREADS", "auto") != "auto":
+    warnings.warn(
+        "`PYTHON_JULIACALL_THREADS` environment variable is set to "
+        + "something other than `auto`, so `amazon-braket-simulator-v2` "
+        + "was not able to set it."
+    )
 
-    for k, default in (
-        ("PYTHON_JULIACALL_HANDLE_SIGNALS", "yes"),
-        ("PYTHON_JULIACALL_THREADS", "auto"),
-        ("PYTHON_JULIACALL_OPTLEVEL", "3"),
-        # let the user's Conda/Pip handle installing things
-        ("JULIA_CONDAPKG_BACKEND", "Null"),
-    ):
-        os.environ[k] = os.environ.get(k, default)
+for k, default in (
+    ("PYTHON_JULIACALL_HANDLE_SIGNALS", "yes"),
+    ("PYTHON_JULIACALL_THREADS", "auto"),
+    ("PYTHON_JULIACALL_OPTLEVEL", "3"),
+    # let the user's Conda/Pip handle installing things
+    ("JULIA_CONDAPKG_BACKEND", "Null"),
+):
+    os.environ[k] = os.environ.get(k, default)
 
 import juliacall
 

--- a/src/braket/simulator_v2/julia_import.py
+++ b/src/braket/simulator_v2/julia_import.py
@@ -1,6 +1,7 @@
 import os
-import sys
 import warnings
+
+import juliacall
 
 # Check if JuliaCall is already loaded, and if so, warn the user
 # about the relevant environment variables. If not loaded,
@@ -28,8 +29,6 @@ for k, default in (
     ("JULIA_CONDAPKG_BACKEND", "Null"),
 ):
     os.environ[k] = os.environ.get(k, default)
-
-import juliacall
 
 jl = juliacall.Base.Module()
 

--- a/test/unit_tests/braket/simulator_v2/test_density_matrix_simulator_v2.py
+++ b/test/unit_tests/braket/simulator_v2/test_density_matrix_simulator_v2.py
@@ -267,7 +267,6 @@ def test_properties():
                     ],
                     "supportedPragmas": [
                         "braket_unitary_matrix",
-                        "braket_result_type_state_vector",
                         "braket_result_type_density_matrix",
                         "braket_result_type_sample",
                         "braket_result_type_expectation",

--- a/test/unit_tests/braket/simulator_v2/test_state_vector_simulator_v2.py
+++ b/test/unit_tests/braket/simulator_v2/test_state_vector_simulator_v2.py
@@ -1573,7 +1573,7 @@ def test_noncontiguous_qubits_jaqcd_multiple_targets():
 def test_run_multiple_single_circuit():
     payload = [
         OpenQASMProgram(
-            source=f"""
+            source="""
             OPENQASM 3.0;
             bit[1] b;
             qubit[1] q;

--- a/test/unit_tests/braket/simulator_v2/test_state_vector_simulator_v2.py
+++ b/test/unit_tests/braket/simulator_v2/test_state_vector_simulator_v2.py
@@ -101,9 +101,7 @@ def test_simulator_run_bell_pair(bell_ir, batch_size, caplog):
     simulator = StateVectorSimulator()
     shots_count = 10000
     if isinstance(bell_ir, JaqcdProgram):
-        result = simulator.run(
-            bell_ir, shots=shots_count, batch_size=batch_size
-        )
+        result = simulator.run(bell_ir, shots=shots_count, batch_size=batch_size)
     else:
         result = simulator.run(bell_ir, shots=shots_count, batch_size=batch_size)
 
@@ -1571,6 +1569,7 @@ def test_noncontiguous_qubits_jaqcd_multiple_targets():
     assert result.measuredQubits == [0, 1]
     assert result.resultTypes[0].value == -1
 
+
 def test_run_multiple_single_circuit():
     payload = [
         OpenQASMProgram(
@@ -1586,6 +1585,7 @@ def test_run_multiple_single_circuit():
     simulator = StateVectorSimulator()
     results = simulator.run_multiple(payload, shots=0)
     assert np.allclose(results[0].resultTypes[0].value, np.array([1, 1]) / np.sqrt(2))
+
 
 def test_run_multiple():
     payloads = [

--- a/test/unit_tests/braket/simulator_v2/test_state_vector_simulator_v2.py
+++ b/test/unit_tests/braket/simulator_v2/test_state_vector_simulator_v2.py
@@ -85,7 +85,6 @@ def test_simulator_run_grcs_16(grcs_16_qubit, batch_size):
     if isinstance(grcs_16_qubit.circuit_ir, JaqcdProgram):
         result = simulator.run(
             grcs_16_qubit.circuit_ir,
-            qubit_count=16,
             shots=0,
             batch_size=batch_size,
         )
@@ -103,7 +102,7 @@ def test_simulator_run_bell_pair(bell_ir, batch_size, caplog):
     shots_count = 10000
     if isinstance(bell_ir, JaqcdProgram):
         result = simulator.run(
-            bell_ir, qubit_count=2, shots=shots_count, batch_size=batch_size
+            bell_ir, shots=shots_count, batch_size=batch_size
         )
     else:
         result = simulator.run(bell_ir, shots=shots_count, batch_size=batch_size)
@@ -729,7 +728,6 @@ def test_simulator_identity(caplog):
         if isinstance(program, JaqcdProgram):
             result = simulator.run(
                 program,
-                qubit_count=2,
                 shots=shots_count,
             )
         else:
@@ -756,7 +754,7 @@ def test_simulator_instructions_not_supported(circuit_noise):
     )
     with pytest.raises(TypeError, match=no_noise):
         if isinstance(circuit_noise, JaqcdProgram):
-            simulator.run(circuit_noise, qubit_count=2, shots=0)
+            simulator.run(circuit_noise, shots=0)
         else:
             simulator.run(circuit_noise, shots=0)
 
@@ -765,7 +763,7 @@ def test_simulator_run_no_results_no_shots(bell_ir):
     simulator = StateVectorSimulator()
     with pytest.raises(ValueError):
         if isinstance(bell_ir, JaqcdProgram):
-            simulator.run(bell_ir, qubit_count=2, shots=0)
+            simulator.run(bell_ir, shots=0)
         else:
             simulator.run(bell_ir, shots=0)
 
@@ -788,7 +786,7 @@ def test_simulator_run_amplitude_shots():
         """
     )
     with pytest.raises(ValueError):
-        simulator.run(jaqcd, qubit_count=2, shots=100)
+        simulator.run(jaqcd, shots=100)
     with pytest.raises(ValueError):
         simulator.run(qasm, shots=100)
 
@@ -838,7 +836,7 @@ def test_simulator_run_statevector_shots():
         """
     )
     with pytest.raises(ValueError):
-        simulator.run(jaqcd, qubit_count=2, shots=100)
+        simulator.run(jaqcd, shots=100)
     with pytest.raises(ValueError):
         simulator.run(qasm, shots=100)
 
@@ -871,7 +869,7 @@ def test_simulator_run_result_types_shots(caplog):
         """
     )
     shots_count = 100
-    jaqcd_result = simulator.run(jaqcd, qubit_count=2, shots=shots_count)
+    jaqcd_result = simulator.run(jaqcd, shots=shots_count)
     qasm_result = simulator.run(qasm, shots=shots_count)
     for result in jaqcd_result, qasm_result:
         assert all([len(measurement) == 2] for measurement in result.measurements)
@@ -911,7 +909,7 @@ def test_simulator_run_result_types_shots_basis_rotation_gates(caplog):
         """
     )
     shots_count = 1000
-    jaqcd_result = simulator.run(jaqcd, qubit_count=2, shots=shots_count)
+    jaqcd_result = simulator.run(jaqcd, shots=shots_count)
     qasm_result = simulator.run(qasm, shots=shots_count)
     for result in jaqcd_result, qasm_result:
         assert all([len(measurement) == 2] for measurement in result.measurements)
@@ -941,7 +939,7 @@ def test_simulator_run_result_types_shots_basis_rotation_gates_value_error():
             )
         )
         shots_count = 1000
-        simulator.run(ir, qubit_count=2, shots=shots_count)
+        simulator.run(ir, shots=shots_count)
 
 
 @pytest.mark.parametrize(
@@ -1031,7 +1029,7 @@ def test_simulator_run_observable_references_invalid_qubit(ir, qubit_count):
     shots_count = 0
     if isinstance(ir, JaqcdProgram):
         with pytest.raises(ValueError):
-            simulator.run(ir, qubit_count=qubit_count, shots=shots_count)
+            simulator.run(ir, shots=shots_count)
     else:
         # index error since you're indexing from a logical qubit
         with pytest.raises(IndexError):
@@ -1046,7 +1044,7 @@ def test_simulator_bell_pair_result_types(
     simulator = StateVectorSimulator()
     ir = bell_ir_with_result(targets)
     if isinstance(ir, JaqcdProgram):
-        result = simulator.run(ir, qubit_count=2, shots=0, batch_size=batch_size)
+        result = simulator.run(ir, shots=0, batch_size=batch_size)
     else:
         result = simulator.run(ir, shots=0, batch_size=batch_size)
     assert len(result.resultTypes) == 2
@@ -1082,7 +1080,7 @@ def test_simulator_fails_samples_0_shots():
         """
     )
     with pytest.raises(ValueError):
-        simulator.run(jaqcd, qubit_count=1, shots=0)
+        simulator.run(jaqcd, shots=0)
     with pytest.raises(ValueError):
         simulator.run(qasm, shots=0)
 
@@ -1161,7 +1159,7 @@ def test_simulator_valid_observables(result_types, expected):
             }
         )
     )
-    result = simulator.run(prog, qubit_count=2, shots=0)
+    result = simulator.run(prog, shots=0)
     for i in range(len(result_types)):
         assert np.allclose(result.resultTypes[i].value, expected[i])
 
@@ -1482,7 +1480,7 @@ def test_simulator_analytic_value_type(jaqcd_string, oq3_pragma, jaqcd_type):
         #pragma braket result {oq3_pragma}
         """
     )
-    result = simulator.run(jaqcd, qubit_count=2, shots=0)
+    result = simulator.run(jaqcd, shots=0)
     assert result.resultTypes[0].type == jaqcd_type
     assert isinstance(result.resultTypes[0].value, np.ndarray)
     result = simulator.run(qasm, shots=0)
@@ -1568,7 +1566,7 @@ def test_noncontiguous_qubits_jaqcd_multiple_targets():
         "results": [{"type": "expectation", "observable": ["z"], "targets": [4]}],
     }
     prg = JaqcdProgram.parse_raw(json.dumps(jaqcd_program))
-    result = StateVectorSimulator().run(prg, qubit_count=2, shots=0)
+    result = StateVectorSimulator().run(prg, shots=0)
 
     assert result.measuredQubits == [0, 1]
     assert result.resultTypes[0].value == -1

--- a/test/unit_tests/braket/simulator_v2/test_state_vector_simulator_v2.py
+++ b/test/unit_tests/braket/simulator_v2/test_state_vector_simulator_v2.py
@@ -1573,6 +1573,21 @@ def test_noncontiguous_qubits_jaqcd_multiple_targets():
     assert result.measuredQubits == [0, 1]
     assert result.resultTypes[0].value == -1
 
+def test_run_multiple_single_circuit():
+    payload = [
+        OpenQASMProgram(
+            source=f"""
+            OPENQASM 3.0;
+            bit[1] b;
+            qubit[1] q;
+            h q[0];
+            #pragma braket result state_vector
+            """
+        )
+    ]
+    simulator = StateVectorSimulator()
+    results = simulator.run_multiple(payload, shots=0)
+    assert np.allclose(results[0].resultTypes[0].value, np.array([1, 1]) / np.sqrt(2))
 
 def test_run_multiple():
     payloads = [


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* remove state vector from list of supported pragmas for new dm simulator

*Testing done:* tests passed locally

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-simulator-v2-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-simulator-v2-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-simulator-v2-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-simulator-v2-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
